### PR TITLE
Fix DEL symbol index

### DIFF
--- a/src/Char.roc
+++ b/src/Char.roc
@@ -321,4 +321,4 @@ us : Char
 us = @Char 31
 ## The ASCII "Delete" (␡) control character
 del : Char
-del = @Char 12
+del = @Char 127


### PR DESCRIPTION
[From Zulip](https://roc.zulipchat.com/#narrow/stream/231634-beginners/topic/Get.20slice.20of.20string/near/450947583)

The `DEL` symbol has incorrect index:

https://github.com/Hasnep/roc-ascii/blob/7185ed9c19cd723c7eb76a86b15e67aa0a235596/src/Char.roc#L324C1-L324C15

According to [this resource](https://www.ascii-code.com/127), it should be `127`
